### PR TITLE
Enemies and knockback

### DIFF
--- a/scenes/enemy.tscn
+++ b/scenes/enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene format=3 uid="uid://yrh5oc72g5fs"]
+[gd_scene format=3 uid="uid://d00ua32coljuv"]
 
 [ext_resource type="Texture2D" uid="uid://cad7ienj21b1j" path="res://assets/images/player/Bertil.png" id="1_7p1mj"]
 [ext_resource type="Script" uid="uid://mi0qmve3nya0" path="res://scripts/enemy.gd" id="1_md0e3"]

--- a/scenes/enemy.tscn
+++ b/scenes/enemy.tscn
@@ -1,0 +1,93 @@
+[gd_scene format=3 uid="uid://yrh5oc72g5fs"]
+
+[ext_resource type="Texture2D" uid="uid://cad7ienj21b1j" path="res://assets/images/player/Bertil.png" id="1_7p1mj"]
+[ext_resource type="Script" uid="uid://mi0qmve3nya0" path="res://scripts/enemy.gd" id="1_md0e3"]
+[ext_resource type="Script" uid="uid://ckfc668g0exx2" path="res://scripts/health.gd" id="4_ipns3"]
+[ext_resource type="Script" uid="uid://cjtnb7uxllscb" path="res://scripts/hurtbox.gd" id="5_8qclf"]
+[ext_resource type="Script" uid="uid://1h33nmi68q4j" path="res://scripts/health_bar.gd" id="6_w8i8w"]
+
+[sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_tuyoq"]
+properties/0/path = NodePath(".:sync_position")
+properties/0/spawn = true
+properties/0/replication_mode = 1
+properties/1/path = NodePath(".:sync_velocity")
+properties/1/spawn = true
+properties/1/replication_mode = 1
+properties/2/path = NodePath(".:enemy_id")
+properties/2/spawn = true
+properties/2/replication_mode = 2
+properties/3/path = NodePath("HealthComponent:sync_health")
+properties/3/spawn = true
+properties/3/replication_mode = 2
+properties/4/path = NodePath(".:sync_facing_direction")
+properties/4/spawn = true
+properties/4/replication_mode = 2
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_g2els"]
+size = Vector2(871.4285, 1614.2856)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_qlg0r"]
+size = Vector2(842.85706, 1614.2856)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dqkch"]
+bg_color = Color(0.19793722, 0.19793725, 0.19793713, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_qlg0r"]
+bg_color = Color(0.6439097, 0.04708454, 0.021919081, 1)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_c4w8v"]
+size = Vector2(1157.1428, 1728.5713)
+
+[node name="Enemy" type="CharacterBody2D" unique_id=438100406]
+scale = Vector2(0.07, 0.07)
+script = ExtResource("1_md0e3")
+
+[node name="EnemySynchronizer" type="MultiplayerSynchronizer" parent="." unique_id=1100668368]
+replication_config = SubResource("SceneReplicationConfig_tuyoq")
+
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=1545070164]
+modulate = Color(1, 0.1973423, 0.112079225, 1)
+texture = ExtResource("1_7p1mj")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=1171786639]
+position = Vector2(-7.142863, 35.714314)
+shape = SubResource("RectangleShape2D_g2els")
+
+[node name="HealthComponent" type="Node2D" parent="." unique_id=1504426426]
+script = ExtResource("4_ipns3")
+max_health = 50
+
+[node name="Hurtbox" type="Area2D" parent="HealthComponent" unique_id=1690071242]
+script = ExtResource("5_8qclf")
+
+[node name="HurtboxCollisionShape2D" type="CollisionShape2D" parent="HealthComponent/Hurtbox" unique_id=1133688344]
+position = Vector2(7.1428432, 35.71429)
+shape = SubResource("RectangleShape2D_qlg0r")
+
+[node name="ProgressBar" type="ProgressBar" parent="." unique_id=1718776609 node_paths=PackedStringArray("health")]
+offset_left = -728.5714
+offset_top = -1314.2856
+offset_right = 728.5714
+offset_bottom = -1214.2858
+theme_override_styles/background = SubResource("StyleBoxFlat_dqkch")
+theme_override_styles/fill = SubResource("StyleBoxFlat_qlg0r")
+show_percentage = false
+script = ExtResource("6_w8i8w")
+health = NodePath("../HealthComponent")
+
+[node name="DamageArea" type="Area2D" parent="." unique_id=180178718]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="DamageArea" unique_id=1392092458]
+position = Vector2(-7.14283, -21.428568)
+shape = SubResource("RectangleShape2D_c4w8v")
+
+[node name="DamageTimer" type="Timer" parent="." unique_id=1605518414]
+wait_time = 0.5
+
+[node name="EdgeCheckLeft" type="RayCast2D" parent="." unique_id=1089003188]
+position = Vector2(-450, 700)
+target_position = Vector2(0, 200)
+
+[node name="EdgeCheckRight" type="RayCast2D" parent="." unique_id=1810134075]
+position = Vector2(450, 700)
+target_position = Vector2(0, 200)

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -43,5 +43,11 @@ spawn_path = NodePath("../Hitboxes")
 
 [node name="Hitboxes" type="Node2D" parent="." unique_id=778308688]
 
+[node name="Enemies" type="Node2D" parent="." unique_id=1551223450]
+
+[node name="EnemySpawner" type="MultiplayerSpawner" parent="." unique_id=388403110]
+_spawnable_scenes = PackedStringArray("uid://yrh5oc72g5fs")
+spawn_path = NodePath("../Enemies")
+
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/HostButton" to="." method="_on_host_button_pressed"]
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/JoinButton" to="." method="_on_join_button_pressed"]

--- a/scenes/main.tscn
+++ b/scenes/main.tscn
@@ -46,7 +46,7 @@ spawn_path = NodePath("../Hitboxes")
 [node name="Enemies" type="Node2D" parent="." unique_id=1551223450]
 
 [node name="EnemySpawner" type="MultiplayerSpawner" parent="." unique_id=388403110]
-_spawnable_scenes = PackedStringArray("uid://yrh5oc72g5fs")
+_spawnable_scenes = PackedStringArray("uid://d00ua32coljuv")
 spawn_path = NodePath("../Enemies")
 
 [connection signal="pressed" from="CanvasLayer/VBoxContainer/HostButton" to="." method="_on_host_button_pressed"]

--- a/scripts/attack_ability.gd
+++ b/scripts/attack_ability.gd
@@ -6,29 +6,25 @@ const HitboxScene = preload("res://scenes/hitbox.tscn")
 @onready var hitbox_spawnpoint: Node2D = get_tree().current_scene.get_node("Hitboxes")
 @onready var player := $".."
 
+@export var base_knockback := Vector2(700, -400)
+
 var can_attack := true
 var owner_node
 
 
 func attack():
-
 	if can_attack: 
-		
 		var hitbox = HitboxScene.instantiate()
 		hitbox_spawnpoint.add_child(hitbox)
 		
-		
-		
 		var facing_direction = player.facing_direction
 		var offset = Vector2(40, 0) * facing_direction
-		
 		owner_node = get_parent()
 		
-		hitbox.setup(20, 0.2, owner_node, offset)
+		hitbox.setup(20, 0.2, owner_node, offset, base_knockback)
 		can_attack = false
 		$attack_again_timer.start()
 		
-		print("Player:", owner_node.player_id, " executed attack. Test 2 In AttackComp")
 
 
 func _on_attack_again_timer_timeout() -> void:

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -1,0 +1,175 @@
+class_name Enemy extends CharacterBody2D
+
+enum AIState { PATROL, CHASE }
+
+@export var damage:int = 15
+
+@export_group("Movement")
+@export var patrol_speed := 100.0
+@export var chase_speed := 175.0
+
+@export_group("AI")
+@export var chase_distance := 250.0
+@export var lose_interest_distance := 350.0 
+
+@export_group("Networking")
+@export var correction_strength := 10.0
+@export var enemy_id: int
+
+@export var sync_position: Vector2
+@export var sync_velocity: Vector2
+@export var sync_facing_direction := 1
+
+var current_state: AIState = AIState.PATROL
+var target_player: CharacterBody2D = null
+
+@onready var health_component: Node2D = $HealthComponent
+@onready var damage_area: Area2D = $DamageArea
+@onready var damage_timer: Timer = $DamageTimer
+
+@onready var edge_check_left: RayCast2D = $EdgeCheckLeft
+@onready var edge_check_right: RayCast2D = $EdgeCheckRight
+
+func _ready() -> void:
+	health_component.set_owner_id(enemy_id)
+	health_component.died.connect(_on_died)
+	
+	if multiplayer.is_server():
+		sync_position = global_position
+		damage_area.area_entered.connect(_on_damage_area_entered)
+		damage_timer.timeout.connect(_on_damage_timer_timeout)
+	else:
+		damage_area.monitoring = false
+
+func _physics_process(delta: float) -> void:
+	if multiplayer.is_server():
+		_server_physics(delta)
+	else:
+		_apply_network_movement(delta)
+
+func _server_physics(delta: float) -> void:
+	if not is_on_floor():
+		velocity += get_gravity() * delta
+		
+	_evaluate_target_and_state()
+	
+	match current_state:
+		AIState.PATROL:
+			_process_patrol_state()
+		AIState.CHASE:
+			_process_chase_state()
+	
+	move_and_slide()
+	
+	sync_position = global_position
+	sync_velocity = velocity
+
+func _evaluate_target_and_state() -> void:
+	var closest_player = _get_closest_player()
+	
+	if current_state == AIState.PATROL:
+		if closest_player and global_position.distance_to(closest_player.global_position) <= chase_distance:
+			target_player = closest_player
+			current_state = AIState.CHASE
+			
+	elif current_state == AIState.CHASE:
+		if not is_instance_valid(target_player) or global_position.distance_to(target_player.global_position) > lose_interest_distance:
+			target_player = null
+			current_state = AIState.PATROL
+
+func _process_patrol_state() -> void:
+	if is_on_wall() or _is_at_edge():
+		_update_facing_direction(sync_facing_direction * -1)
+		
+	velocity.x = sync_facing_direction * patrol_speed
+
+func _process_chase_state() -> void:
+	if not is_instance_valid(target_player):
+		return
+		
+	var direction_to_target = sign(target_player.global_position.x - global_position.x)
+	
+	if direction_to_target != 0 and direction_to_target != sync_facing_direction:
+		_update_facing_direction(direction_to_target)
+		
+	if _is_at_edge():
+		velocity.x = 0
+	else:
+		velocity.x = sync_facing_direction * chase_speed
+
+## Helper function to cleanly evaluate the correct raycast
+func _is_at_edge() -> bool:
+	if not is_on_floor():
+		return false
+		
+	if sync_facing_direction == 1:
+		return not edge_check_right.is_colliding()
+	else:
+		return not edge_check_left.is_colliding()
+
+func _update_facing_direction(new_direction: int) -> void:
+	if new_direction == 0: return
+	sync_facing_direction = sign(new_direction)
+	
+	$Sprite2D.flip_h = (sync_facing_direction == -1)
+
+func _get_closest_player() -> CharacterBody2D:
+	var players_node = get_tree().current_scene.get_node_or_null("Players")
+	if not is_instance_valid(players_node):
+		return null
+		
+	var closest: CharacterBody2D = null
+	var min_dist := INF
+	
+	for player in players_node.get_children():
+		if player is CharacterBody2D: 
+			var dist = global_position.distance_to(player.global_position)
+			if dist < min_dist:
+				min_dist = dist
+				closest = player
+				
+	return closest
+
+func _on_damage_area_entered(area: Area2D) -> void:
+	if not multiplayer.is_server():
+		return
+	
+	if _try_damage(area) and damage_timer.is_stopped():
+		damage_timer.start()
+
+func _on_damage_timer_timeout() -> void:
+	var hit_anyone := false
+	var overlapping_areas = damage_area.get_overlapping_areas()
+	
+	for area in overlapping_areas:
+		if _try_damage(area):
+			hit_anyone = true
+			
+	if not hit_anyone:
+		damage_timer.stop()
+
+func _try_damage(area: Area2D) -> bool:
+	if area.has_method("receive_hit") and area.get("owner_id") != null:
+		if area.owner_id > 0:
+			area.receive_hit(damage)
+			return true
+	return false
+
+func _on_died() -> void:
+	if multiplayer.is_server():
+		queue_free()
+
+func _apply_network_movement(_delta: float) -> void:
+	velocity = sync_velocity
+	_update_facing_direction(sync_facing_direction)
+	
+	var drift_distance = global_position.distance_to(sync_position)
+	
+	if drift_distance > 100.0:
+		global_position = sync_position
+		reset_physics_interpolation()
+	elif drift_distance > 1.0:
+		var direction_to_server = sync_position - global_position
+		velocity += direction_to_server * correction_strength
+	
+	move_and_slide()

--- a/scripts/enemy.gd
+++ b/scripts/enemy.gd
@@ -22,6 +22,7 @@ enum AIState { PATROL, CHASE }
 
 var current_state: AIState = AIState.PATROL
 var target_player: CharacterBody2D = null
+var knockback_stun_time_left := 0.0
 
 @onready var health_component: Node2D = $HealthComponent
 @onready var damage_area: Area2D = $DamageArea
@@ -33,6 +34,8 @@ var target_player: CharacterBody2D = null
 func _ready() -> void:
 	health_component.set_owner_id(enemy_id)
 	health_component.died.connect(_on_died)
+	
+	health_component.knockback_received.connect(_on_knockback_received)
 	
 	if multiplayer.is_server():
 		sync_position = global_position
@@ -51,6 +54,15 @@ func _server_physics(delta: float) -> void:
 	if not is_on_floor():
 		velocity += get_gravity() * delta
 		
+	# Handle knockback stun state
+	if knockback_stun_time_left > 0.0:
+		knockback_stun_time_left -= delta
+		velocity.x = move_toward(velocity.x, 0, 1000 * delta) # Apply friction
+		move_and_slide()
+		sync_position = global_position
+		sync_velocity = velocity
+		return # Skip AI logic while stunned
+	
 	_evaluate_target_and_state()
 	
 	match current_state:
@@ -63,6 +75,11 @@ func _server_physics(delta: float) -> void:
 	
 	sync_position = global_position
 	sync_velocity = velocity
+
+func _on_knockback_received(knockback: Vector2) -> void:
+	if multiplayer.is_server():
+		velocity = knockback
+		knockback_stun_time_left = 0.3 # 300ms stun
 
 func _evaluate_target_and_state() -> void:
 	var closest_player = _get_closest_player()
@@ -151,7 +168,7 @@ func _on_damage_timer_timeout() -> void:
 func _try_damage(area: Area2D) -> bool:
 	if area.has_method("receive_hit") and area.get("owner_id") != null:
 		if area.owner_id > 0:
-			area.receive_hit(damage)
+			area.receive_hit(damage, Vector2(400, -800), global_position)
 			return true
 	return false
 

--- a/scripts/enemy.gd.uid
+++ b/scripts/enemy.gd.uid
@@ -1,0 +1,1 @@
+uid://mi0qmve3nya0

--- a/scripts/health.gd
+++ b/scripts/health.gd
@@ -11,6 +11,7 @@ var owner_id: int # The player that owns the health component
 
 signal health_changed(new_value: int)
 signal died
+signal knockback_received(actual_knockback: Vector2)
 
 # Starts character with full health
 func _ready() -> void:
@@ -21,19 +22,22 @@ func _ready() -> void:
 	
 
 ## Decreases the characters health by the input amount.
-func take_damage(damage: int):
+func take_damage(damage: int, base_knockback: Vector2 = Vector2.ZERO, source_position: Vector2 = Vector2.ZERO):
+	sync_health = max(sync_health - damage, 0)
 	
-		print( "Player:",owner_id, " took damage. Test 6 In HealthComp" )
-		sync_health = max(sync_health - damage, 0)
-
+	# Calculate and emit knockback if a valid vector was provided
+	if base_knockback != Vector2.ZERO:
+		var body = get_parent()
+		# Determine relative direction: 1 for right, -1 for left
+		var x_dir = sign(body.global_position.x - source_position.x)
+		if x_dir == 0: 
+			x_dir = 1 # Fallback if positions are perfectly identical
 		
-		if sync_health == 0:
-			dies()
-	
-# Reduces health when "L" key is pressed. For testing purposes.
-func _input(event: InputEvent) -> void:
-	if event.is_action_pressed("decrease_hp") and not event.is_echo() :
-		take_damage(10)
+		var actual_knockback = Vector2(base_knockback.x * x_dir, base_knockback.y)
+		knockback_received.emit(actual_knockback)
+
+	if sync_health == 0:
+		dies()
 
 func dies():
 	died.emit()

--- a/scripts/hitbox.gd
+++ b/scripts/hitbox.gd
@@ -14,6 +14,7 @@ var follow_target: Node2D # The player that spawns the hitbox,
  # Hitbox should be offset to left/right of the player center.
 var offset: Vector2 # How much the hitbox should be offset
 var hurtbox_owner
+var knockback_vector: Vector2
 
 @onready var collision_shape: CollisionShape2D = $CollisionShape2D
 
@@ -21,19 +22,19 @@ var hurtbox_owner
 # Assigns the hitbox scene objects with values. setup() is needed 
 # since the object will be replicated with multiplayerSpawner, 
 # which does not replicate runtime values like global_location - said GPT
-func setup(_attacker_dmg: int, _hitbox_lifetime: float, owner_node: Node2D, _offset: Vector2) -> void:
+func setup(_attacker_dmg: int, _hitbox_lifetime: float, owner_node: Node2D, _offset: Vector2, _knockback: Vector2 = Vector2.ZERO) -> void:
 		attacker_dmg = _attacker_dmg
 		hitbox_lifetime = _hitbox_lifetime 
 		
 		follow_target = owner_node
 		offset = _offset
+		knockback_vector = _knockback
 
 		global_position = follow_target.global_position + offset
 		
 		if hitbox_lifetime > 0.0:
 			await get_tree().create_timer(hitbox_lifetime).timeout
 			queue_free()
-		print("Player:", follow_target.player_id, " now has a hitbox following them. Test 3 In hitbox")
 		
 func _physics_process(delta):
 	# Makes the hitbox follow player position
@@ -56,14 +57,10 @@ func _on_area_entered(area: Area2D) -> void:
 	if not area.has_method("receive_hit"):
 		return
 	
-	
 	hurtbox_owner = area.owner_id
 	
-	print("Player:", hurtbox_owner, " touched the hitbox. Test 4 In hitbox")
 	# To prevent self damage
 	if hurtbox_owner == follow_target.player_id:
 		return
 
-	area.receive_hit(attacker_dmg)
-		
-		
+	area.receive_hit(attacker_dmg, knockback_vector, global_position)

--- a/scripts/hurtbox.gd
+++ b/scripts/hurtbox.gd
@@ -12,9 +12,8 @@ func _ready() -> void:
 	
 	
 
-func receive_hit(damage: int) -> void:
-	player_health.take_damage(damage)
-	print("Player:", owner_id, " called take damage. Test 5 In Hurtbox")
+func receive_hit(damage: int, base_knockback: Vector2 = Vector2.ZERO, source_position: Vector2 = Vector2.ZERO) -> void:
+	player_health.take_damage(damage, base_knockback, source_position)
 	
 
 

--- a/scripts/networking/network.gd
+++ b/scripts/networking/network.gd
@@ -2,6 +2,7 @@ extends Node
 
 const PORT: int = 42069
 var player_scene = preload("res://scenes/player.tscn")
+var enemy_scene = preload("res://scenes/enemy.tscn")
 
 # Changed name to describe its function, and moved to _on_host_button_pressed()
 # so that only the host's/server's sceneTree is the spawnpoint. 
@@ -10,6 +11,8 @@ var player_scene = preload("res://scenes/player.tscn")
 
 #@onready var world = get_node("../World") Removed
 var _player_spawn_node #Replacement
+var _enemy_spawn_node
+var _enemy_id_counter := -1
 
 # Moved logic to "Main" node instead of in networking
 
@@ -27,6 +30,7 @@ func _ready():
 func _become_host() -> void:
 	print("Starting host")
 	_player_spawn_node = get_tree().current_scene.get_node("Players")
+	_enemy_spawn_node = get_tree().current_scene.get_node("Enemies")
 	
 	var peer = ENetMultiplayerPeer.new()
 	peer.create_server(PORT)
@@ -39,6 +43,9 @@ func _become_host() -> void:
 	
 	
 	_add_player(multiplayer.get_unique_id())
+	
+	_spawn_enemy(Vector2(-400, 300)) # temporary positions and spawns
+	_spawn_enemy(Vector2(500, 100))
 	
 func _join_as_non_host_client(ip_input) -> void:
 	print("Joining as client")
@@ -67,6 +74,18 @@ func _join_as_non_host_client(ip_input) -> void:
 	
 	multiplayer.server_disconnected.connect(_on_server_disconnected)
 	#request_players.rpc_id(1)
+
+func _spawn_enemy(spawn_position: Vector2) -> void:
+	var enemy = enemy_scene.instantiate()
+	enemy.enemy_id = _enemy_id_counter
+	# Name the node predictably for the MultiplayerSpawner
+	enemy.name = "Enemy_" + str(abs(_enemy_id_counter)) 
+	
+	enemy.global_position = spawn_position
+	
+	_enemy_spawn_node.add_child(enemy)
+	
+	_enemy_id_counter -= 1 # Decrement so next enemy is -2, then -3, etc.
 	
 func _add_player(id):
 	print("Player %s joined the game" % id)

--- a/scripts/player_controller.gd
+++ b/scripts/player_controller.gd
@@ -31,11 +31,12 @@ var do_attack := false # Tells player to attack, updated in InputSynchronizer
 var dashing := false # To check if currently dashing
 var can_dash := true # Determines if you can dash, tied to timer
 
+var knockback_stun_time_left := 0.0
+
 
 func _ready():
-	
-
 	$HealthComponent.set_owner_id(player_id)
+	$HealthComponent.knockback_received.connect(_on_knockback_received)
 	
  	# Only the client player has a camera enabled, so always 
 	# follows the playable characther
@@ -49,18 +50,17 @@ func _ready():
 
 # Moved most things to _apply_movement_from_input
 func _physics_process(delta: float) -> void:
-	
 	if multiplayer.is_server(): 
-		
 		moving_direction = input_synchronizer.input_direction
-		facing_direction = moving_direction
+		
+		if moving_direction != 0 and knockback_stun_time_left <= 0.0:
+			facing_direction = moving_direction
 		
 		_apply_movement_from_input(delta)
 		sync_position = global_position
 		sync_velocity = velocity
 		
 		if do_attack:
-			print("Player:",player_id, " called attack. Test 1 In Player")
 			attack_component.attack()
 			do_attack = false
 	else:
@@ -86,6 +86,14 @@ func _apply_network_movement(_delta):
 
 ## Manages basic movement, namely jumping and walking.
 func _apply_movement_from_input(delta):
+	if knockback_stun_time_left > 0.0:
+		knockback_stun_time_left -= delta
+		if not is_on_floor():
+			velocity += get_gravity() * delta
+		# Apply friction to slow down horizontal slide
+		velocity.x = move_toward(velocity.x, 0, 1000 * delta) 
+		move_and_slide()
+		return # Exit early so player input is ignored during stun!
 	
 	# Handles gravity
 	if not is_on_floor() and not dashing:
@@ -108,14 +116,17 @@ func _apply_movement_from_input(delta):
 			velocity.x = move_toward(velocity.x, 0, SPEED)
 	
 	move_and_slide()
+	
+func _on_knockback_received(knockback: Vector2) -> void:
+	if multiplayer.is_server():
+		velocity = knockback
+		knockback_stun_time_left = 0.3 # 300 milliseconds of stun
+		# Cancel active states
+		do_jump = false
+		do_dash = false
+		dashing = false
 
-
-# CURRENT BUG!!!
-## The player dashes forward in a straight line, dash is
-## then placed on cooldown.
 func dash():
-	
-	
 	dashing = true
 	can_dash = false
 	# Dash duration


### PR DESCRIPTION
This PR introduces networked, server-authoritative enemies with a simple state machine, and expands our existing combat pipeline to support a universal knockback system for all character bodies (both players and enemies). The enemy AI is simple but surprisingly lengthy for the limited functionality, but it should be fine until we figure out exactly how they should behave.

There are two issues still: If a player stands right above an enemy, the enemy will constantly flip back and forth. Some test values are still used, such as a hard coded 300ms stun, and knockback vectors for the enemy.

Here's an AI-written summary:

**Enemy AI & Networking**
* Added `Enemy` scene with `MultiplayerSynchronizer` tracking position, velocity, and facing direction.
* Implemented a robust Patrol/Chase Finite State Machine. Includes hysteresis (`chase_distance` vs `lose_interest_distance`) to prevent rapid state-toggling.
* Added a dual-RayCast edge detection system (`EdgeCheckLeft`/`EdgeCheckRight`) to cleanly prevent enemies from walking off ledges.
* Introduced a negative ID assignment for enemies in `network.gd` to smoothly integrate with our existing Hitbox team-check logic.
* Set up `EnemySpawner` in the main scene to replicate enemies to clients.

**Combat & Knockback System**
* Expanded `Hitbox`, `Hurtbox`, and `HealthComponent` to pass knockback vectors and source positions.
* `HealthComponent` now handles relative directional math (calculating whether to push left or right based on the attacker's position) and emits a `knockback_received` signal.
* Both `player_controller.gd` and `enemy.gd` now listen for `knockback_received`. When triggered, they enter a brief stun state (0.3s) where input/AI is ignored, velocity is overridden by the knockback force, and friction is applied.
* *Note: The knockback system supports both push and pull. A negative X value in the base knockback vector will pull the target toward the attacker.*